### PR TITLE
Add projectBaseUrl CLI arg

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -43,6 +43,7 @@ function getInputs() {
         .option('-v, --verbose', 'displays detailed error information')
         .option('-a, --alive <code>', 'comma separated list of HTTP codes to be considered as alive', commaSeparatedCodesList)
         .option('-r, --retry', 'retry after the duration indicated in \'retry-after\' header when HTTP code is 429')
+        .option('--projectBaseUrl <url>', 'the URL to use for {{BASEURL}} replacement')
         .arguments('[filenamesOrUrls...]')
         .action(function (filenamesOrUrls) {
             let filenameForOutput;
@@ -102,8 +103,12 @@ function getInputs() {
         input.opts.verbose = (program.verbose === true);
         input.opts.retryOn429 = (program.retry === true);
         input.opts.aliveStatusCodes = program.alive;
-        // set the projectBaseUrl to the current working directory, so that `{{BASEURL}}` can be resolved to the project root.
-        input.opts.projectBaseUrl = `file://${process.cwd()}`;
+        if (program.projectBaseUrl) {
+            input.opts.projectBaseUrl = `file://${program.projectBaseUrl}`;
+        } else {
+            // set the default projectBaseUrl to the current working directory, so that `{{BASEURL}}` can be resolved to the project root.
+            input.opts.projectBaseUrl = `file://${process.cwd()}`;
+        }
     }
 
     return inputs;

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -103,7 +103,7 @@ function getInputs() {
         input.opts.verbose = (program.verbose === true);
         input.opts.retryOn429 = (program.retry === true);
         input.opts.aliveStatusCodes = program.alive;
-        if (program.projectBaseUrl !== undefined) {
+        if (program.projectBaseUrl) {
             input.opts.projectBaseUrl = `file://${program.projectBaseUrl}`;
         } else {
             // set the default projectBaseUrl to the current working directory, so that `{{BASEURL}}` can be resolved to the project root.

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -103,7 +103,7 @@ function getInputs() {
         input.opts.verbose = (program.verbose === true);
         input.opts.retryOn429 = (program.retry === true);
         input.opts.aliveStatusCodes = program.alive;
-        if (program.projectBaseUrl) {
+        if (program.projectBaseUrl !== undefined) {
             input.opts.projectBaseUrl = `file://${program.projectBaseUrl}`;
         } else {
             // set the default projectBaseUrl to the current working directory, so that `{{BASEURL}}` can be resolved to the project root.


### PR DESCRIPTION
The JavaScript API [provides](https://github.com/pvallone/markdown-link-check/blob/49e52e41a7c25eec7ee3c820c1a7e1eb79dddf52/index.js#L19) a way to configure this via `opts.projectBaseUrl` already, and it would be useful to be able to set it from a CLI context.

Example usage:

`markdown-link-check --projectBaseUrl "c:/path/to/repo/root"`